### PR TITLE
Add packages to setup install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import find_packages, setup
 
 setup(
+    install_requires=[
+        'colorama',
+        'termcolor',
+    ],
     name='aptos',
     version='1.0.2',
     url='https://github.com/pennsignals/aptos',


### PR DESCRIPTION
This is a follow-up to pull request #15, by updating `setup.py` to include 2 newly introduced packages. 
To verify, I run `setup.py` in a new python environment and both packages were installed successfully. 
![aptossnap-install](https://user-images.githubusercontent.com/12599488/34090201-1bea1dd2-e36a-11e7-8e0a-f7b6050f9339.PNG)
