### PR TITLE
Adding preliminary support for converting json schema to apache parquet schema.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/aptos/jinja_helper.py
+++ b/aptos/jinja_helper.py
@@ -1,0 +1,16 @@
+from jinja2 import Environment, FileSystemLoader
+
+class JinjaHelper:
+
+    jinja_env = None
+
+    @classmethod
+    def create_jinja_env(cls):
+        file_loader = FileSystemLoader('templates')
+        JinjaHelper.jinja_env = Environment(loader=file_loader)
+
+    @staticmethod
+    def get_template(template_name):
+        if JinjaHelper.jinja_env is None:
+            JinjaHelper.create_jinja_env()
+        return JinjaHelper.jinja_env.get_template(template_name)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     install_requires=[
         'colorama',
         'termcolor',
+        'jinja2'
     ],
     name='aptos',
     version='1.0.2',

--- a/templates/inner_schema.jinja2
+++ b/templates/inner_schema.jinja2
@@ -1,0 +1,5 @@
+{% extends "schema.jinja2" -%}
+{% block schema_content -%}
+{% macro fix_indent() %}{{ body }}{% endmacro -%}
+{{ fix_indent()|indent(width=2,first=True) -}}
+{% endblock -%}

--- a/templates/macros.jinja2
+++ b/templates/macros.jinja2
@@ -1,0 +1,1 @@
+{% macro fix_indent(body) %}{{ body }}{% endmacro -%}

--- a/templates/object.jinja2
+++ b/templates/object.jinja2
@@ -1,0 +1,5 @@
+{% import "macros.jinja2" as macros -%} 
+{{ obj_name }} {
+{% block object_content -%}
+{{ macros.fix_indent(body)|indent(width=2,first=True) -}}
+{% endblock -%}}

--- a/templates/schema.jinja2
+++ b/templates/schema.jinja2
@@ -1,0 +1,4 @@
+message ParquetSchema {
+{% block schema_content %}
+{% endblock %}
+}

--- a/tests/schema/person
+++ b/tests/schema/person
@@ -1,0 +1,28 @@
+{
+    "title": "Person",
+    "type": "object",
+    "properties": {
+        "firstName": {
+            "type": "string"
+        },
+        "lastName": {
+            "type": "string"
+        },
+        "age": {
+            "type" : "integer"
+        },
+        "address": {
+            "type" : "object",
+            "title": "Address",
+            "properties": {
+                "street_name": {
+                    "type": "string"
+                },
+                "zipcode": {
+                    "type": "integer"
+                }
+            }
+        }
+    },
+    "required": [ "firstName", "age" ]
+}


### PR DESCRIPTION
Related to issue: https://github.com/pennsignals/aptos/issues/2
Objective: hoping to get advice about approach.

Simple test:
```
$ aptos convert -format parquet tests/schema/person
message ParquetSchema {
  Person {
    required binary firstName (UTF8);
    optional binary lastName (UTF8);
    required int32 age;
    Address {
      optional binary street_name (UTF8);
      optional int32 zipcode;
    }
  }
}
```